### PR TITLE
Add battery health (SOH) attribute

### DIFF
--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -172,6 +172,7 @@ def _parse_see_args(message):
             'trip': int(message['Trip']),
             'odometer': int(message['Odo']),
             'battery_temperature': float(message['BatTemp']),
+            'battery_health': float(message['SOH']),
             'outside_temperature': float(message['Amb']),
             'plug_state': PLUG_STATES[int(message['PlugState'])],
             'charge_mode': CHARGE_MODES[int(message['ChrgMode'])],


### PR DESCRIPTION
My LeafSpy gives me state of battery health (SOH), so this PR adds SOH as an attribute. But perhaps SOH isn't available in all regions/models? Test it out—if it's not, maybe we'll have to build in a check.