### PR TITLE
Cast odometer to float instead of int

### DIFF
--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -170,7 +170,7 @@ def _parse_see_args(message):
         'attributes': {
             'amp_hours': float(message['AHr']),
             'trip': int(message['Trip']),
-            'odometer': int(message['Odo']),
+            'odometer': float(message['Odo']),
             'battery_temperature': float(message['BatTemp']),
             'outside_temperature': float(message['Amb']),
             'plug_state': PLUG_STATES[int(message['PlugState'])],


### PR DESCRIPTION
For me, LeafSpy reports the odometer as a string representation of a float. Previously, ha-leafspy was passing that string representation into `int()`, which [doesn't work](https://stackoverflow.com/questions/1841565/valueerror-invalid-literal-for-int-with-base-10) and was causing an error (#15). This passes the string into `float()` instead, solving the issue.