### PR TITLE
Address deprecated async_get_registry

### DIFF
--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -50,7 +50,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     hass.data[LS_DOMAIN]['context'].set_async_see(_receive_data)
 
     # Restore previously loaded devices
-    dev_reg = await device_registry.async_get_registry(hass)
+    dev_reg = device_registry.async_get(hass)
     dev_ids = {
         identifier[1]
         for device in dev_reg.devices.values()


### PR DESCRIPTION
With 2022.6, I started getting the following warning regarding ha-leafspy:

``Detected integration that uses deprecated `async_get_registry` to access device registry, use async_get instead``

I followed what was done [here](https://github.com/custom-components/alexa_media_player/issues/1604) for a different integration. I now get no warning, and everything seems to be working fine.