### PR TITLE
Address deprecated SOURCE_TYPE_GPS constant

### DIFF
--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -7,7 +7,7 @@ from homeassistant.const import (
     ATTR_LONGITUDE,
     ATTR_BATTERY_LEVEL,
 )
-from homeassistant.components.device_tracker.const import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.components.device_tracker.config_entry import (
     TrackerEntity
 )
@@ -118,7 +118,7 @@ class LeafSpyEntity(TrackerEntity, RestoreEntity):
     @property
     def source_type(self):
         """Return the source type of the car."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     @property
     def device_info(self):

--- a/custom_components/leafspy/manifest.json
+++ b/custom_components/leafspy/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "leafspy",
   "name": "Leaf Spy",
-  "documentation": "https://github.com/jesserockz/ha-leafspy/blob/master/README.md",
-  "issue_tracker": "https://github.com/jesserockz/ha-leafspy/issues",
-  "requirements": [],
-  "dependencies": ["http"],
   "codeowners": ["@jesserockz"],
   "config_flow": true,
-  "version": "0.2.0",
-  "iot_class": "local_push"
+  "dependencies": ["http"],
+  "documentation": "https://github.com/jesserockz/ha-leafspy/blob/master/README.md",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/jesserockz/ha-leafspy/issues",
+  "requirements": [],
+  "version": "0.2.0"
 }

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -1,10 +1,10 @@
 {
   "config": {
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary."
+      "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "\n\nOpen the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'<Car Name>'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "\n\nOpen the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
     },
     "step": {
       "user": {

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -1,10 +1,10 @@
 {
   "config": {
     "abort": {
-      "one_instance_allowed": "Only a single instance is necessary."
+      "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "\n\nOpen the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'<Car Name>'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "\n\nOpen the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
     },
     "step": {
       "user": {


### PR DESCRIPTION
This addresses the warning that `SOURCE_TYPE_GPS` "is a deprecated constant which will be removed in HA Core 2025.1. Use SourceType.GPS instead."

@jesserockz, I see that you are no longer monitoring this repository. Will you still be merging PRs, or do you want to point users towards my fork instead? I plan to use this integration for the foreseeable future, so have an incentive to maintain it.