### PR TITLE
Checking for 1 as a string to fix the binary sensor

### DIFF
--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -31,7 +31,7 @@ BINARY_SENSOR_TYPES = [
         translation_key="power_switch_state",
         device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda data: data.get("PwrSw"),
-        transform_fn=lambda x: x == 1,
+        transform_fn=lambda x: x == '1',
         icon="mdi:power",
     )
 ]


### PR DESCRIPTION
Fixes https://github.com/jesserockz/ha-leafspy/issues/31

![image](https://github.com/user-attachments/assets/a6567fb0-a5e3-44c3-a55c-d0eca88b7d86)