### PR TITLE
Add proper sensor and binary sensor entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=leafspy)
   
-5. Configure your Leaf Spy app settings using the information that the integration displays on screen. If you don't have the app in front of you, copy down the on-screen information; the generated password will only be shown this once. If you don't copy it down, you'll have to uninstall the integration, restart, and reinstall.
+5. Configure your Leaf Spy app settings using the information that the integration displays on screen. If you don't have the app in front of you, copy down the password. The generated password will only be shown this once; if you don't copy it down, you'll have to uninstall the integration, restart, and reinstall.
 
 ## Entities
 _See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Help-1.5.0.pdf#page=70) for more details on the data that the app sends._
@@ -43,27 +43,27 @@ _See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Hel
 ### Sensors
 | Entity ID | Unit reported by LeafSpy | Note |
 | :-- | :-- | :-- |
-| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI |
+| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI. |
 | sensor.leaf_battery_capacity | Ah | |
-| sensor.leaf_battery_conductance | % | Referred to as Hx in the LeafSpy manual |
+| sensor.leaf_battery_conductance | % | Referred to as Hx in the LeafSpy manual. |
 | sensor.leaf_battery_current | A | |
-| sensor.leaf_battery_gids |  Gids | |
 | sensor.leaf_battery_health | % | | 
 | sensor.leaf_battery_state_of_charge | % | |
-| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI |
+| sensor.leaf_battery_stat_of_charge_gids |  Gids | |
+| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI. |
 | sensor.leaf_battery_voltage | V | |
 | sensor.leaf_charge_mode | --- | |
 | sensor.leaf_charge_power | W | Not very accurate. For example, when charging via level 2 charging, it just guesses 6,000 W. |
 | sensor.leaf_elevation | m | Unit adjustable in HA UI |
-| sensor.leaf_front_wiper | --- | Not known if Leaf Spy reports this. File an issue if you see info here. |
+| sensor.leaf_front_wiper_status | --- | To get this information you may need to make a custom screen in LeafSpy to read wiper status. |
 | sensor.leaf_motor_speed | RPM | |
-| sensor.leaf_odometer | km | You must indicate in LeafSpy whether your car reports in km or mi. Unit adjustable in HA UI |
+| sensor.leaf_odometer | km | You must indicate _in LeafSpy_ whether your car reports in km or mi. Unit later adjustable in HA UI. |
 | sensor.leaf_phone_battery | % | |
-| sensor.leaf_plug | --- | Reports "Not plugged", "Partial Plugged", or "Plugged" |
-| sensor.leaf_sequence_number | --- | A number that increments with each report from Leaf Spy |
-| sensor.leaf_speed | km/h | Unit adjustable in HA UI |
-| sensor.leaf_trip_number | --- | Tracks total number of trips taken |
-| sensor.leaf_vin | ---  | Car unique identifier | 
+| sensor.leaf_plug_status | --- | Reports "Not plugged", "Partial Plugged", or "Plugged." |
+| sensor.leaf_sequence_number | --- | A number that increments with each report from Leaf Spy. |
+| sensor.leaf_speed | km/h | Unit adjustable in HA UI. |
+| sensor.leaf_trip_number | --- | Tracks total number of trips taken. |
+| sensor.leaf_vin | ---  | Car unique identifier. | 
 
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/jesserockz/ha-leafspy.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -9,38 +9,62 @@
 
 <p align="center"><img src="leafspy.png" width="64"></p>
 
-This Home Assistant component integrates with the LeafSpy [Android](https://play.google.com/store/apps/details?id=com.Turbo3.Leaf_Spy_Pro&hl=en_US) and [iOS](https://apps.apple.com/us/app/leafspy-pro/id967376861). Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product/B0755N61PW/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1)) into your Nissan Leaf. Open up LeafSpy and pair your phone with the adapter. It will then read information from your car. This integration will allow your phone to submit that info to Home Assistant.
+This Home Assistant component enables you to get information from your Nissan Leaf car into Home Assistant by integrating with the LeafSpy [Android](https://play.google.com/store/apps/details?id=com.Turbo3.Leaf_Spy_Pro&hl=en_US) or [iOS](https://apps.apple.com/us/app/leafspy-pro/id967376861) apps.
+
+Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product/B0755N61PW/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1)) into your Nissan Leaf. Open up LeafSpy and pair your phone with the adapter. It will then read information from your car. This integration will allow your phone to submit that info to Home Assistant.
 
 ## Installation and configuration
 
 1. [Install HACS](https://www.hacs.xyz/docs/use/configuration/basic/).
-2. Add this to HACS as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) by pressing this button.
+2. Add this to HACS as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) by pressing this button and pressing "Download" in the bottom right.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jesserockz&repository=ha-leafspy&category=integration)
 
 3. Restart Home Assistant
-4. In the UI go to "Configuration" -> "Integrations" click "+" and search for "Leaf Spy"
-5. Configure your Leaf Spy app using the information that the integration displays on screen. If you don't have the app in front of you, copy down the on-screen information; the generated password will only be shown this once. If you don't copy it down, you'll have to uninstall the integration, restart, and reinstall.
+4. Add the Leaf Spy integration by pressing this button.
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=leafspy)
+  
+5. Configure your Leaf Spy app settings using the information that the integration displays on screen. If you don't have the app in front of you, copy down the on-screen information; the generated password will only be shown this once. If you don't copy it down, you'll have to uninstall the integration, restart, and reinstall.
 
 ## Entities
-_See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Help-1.5.0.pdf#page=70) for more details on the entities it sends._
+_See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Help-1.5.0.pdf#page=70) for more details on the data that the app sends._
 
 ### Device tracker
-| Entity ID | Entity Name | Description |
-| :-- | :-: | :-- |
-| device_tracker.leaf | Leaf | Tracks latitude, longitude, GPS accuracy, and battery level |
+| Entity ID | Note |
+| :-- | :-- |
+| device_tracker.leaf | Tracks latitude, longitude, GPS accuracy, and battery level |
 
 ### Binary sensor
-| Entity ID | Entity Name | Description |
-| :-- | :-: | :-- |
-| binary_sensor.leaf_power | Leaf power | Indicates whether car is turned on |
+| Entity ID |
+| :-- |
+| binary_sensor.leaf_power |
 
 ### Sensors
-| Entity ID | Entity Name | Description |
-| :-- | :-: | :-- |
-| sensor.leaf_ambient_temperature | Leaf ambient temperature | Indicates temperature outside of car |
-| sensor.leaf_battery_capacity | Leaf battery capacity | Indicates battery capacity (Ah) |
-| ... | ... | ... |
+| Entity ID | Unit reported by LeafSpy | Note |
+| :-- | :-- | :-- |
+| sensor.leaf_ambient_temperature | °C / °F | Unit adjustable in HA UI BUT ALSO... |
+| sensor.leaf_battery_capacity | Ah | |
+| sensor.leaf_battery_conductance | % | Referred to as Hx |
+| sensor.leaf_battery_current | A | |
+| sensor.leaf_battery_gids |  Gids | |
+| sensor.leaf_battery_health | % | | 
+| sensor.leaf_battery_state_of_charge | % | |
+| sensor.leaf_battery_temperature | °C / °F | Unit adjustable in HA UI BUT ALSO... |
+| sensor.leaf_battery_voltage | V | |
+| sensor.leaf_charge_mode | --- | |
+| sensor.leaf_elevation | m | Unit adjustable in HA UI |
+| sensor.leaf_front_wiper | --- | Not known if Leaf Spy reports this. File an issue if you see info here. |
+| sensor.leaf_motor_speed | RPM | |
+| sensor.leaf_odometer | km | Unit adjustable in HA UI |
+| sensor.leaf_phone_battery | % | |
+| sensor.leaf_plug | --- | Reports "Not plugged", "Partial Plugged", or "Plugged" |
+| sensor.leaf_sequence_number | --- | A number that increments with each report from Leaf Spy |
+| sensor.leaf_speed | km/h | Unit adjustable in HA UI |
+| sensor.leaf_temperature_units | --- | Shows whether LeafSpy is set to C or F. [Maybe no need to expose?] |
+| sensor.leaf_trip_number | --- | Tracks total number of trips taken |
+| sensor.leaf_vin | ---  | Car unique identifier | 
+
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/jesserockz/ha-leafspy.svg?style=for-the-badge
 [commits]: https://github.com/jesserockz/ha-leafspy/commits/main

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product
 - In the **Units** section:
   - Choose `°C`
   - `Convert Outside Temperature`: `On`
-  - `CAN Odometer in Miles`: `On` if you see the option and if your car odometer displays in miles
+  - `CAN Odometer in Miles`: `On` (if you see the option and if your car odometer displays in miles)
 - In the **Server** section:
   - `Enable`: `On`
   - `Send Interval`: Whatever frequency you prefer

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ _Component to integrate with [leafspy][leafspy]._
 
 Platform | Description
 -- | --
-`device_tracker` | Track a Nissan Leaf using the Leaf Spy app. Data about the vehicle sent from Leaf Spy will be viewable under Attributes
+`device_tracker` | Track a Nissan Leaf using the Leaf Spy app. 
+`sensor` | All data about the vehicle sent from Leaf Spy is displayed as independent sensors. They won't appear in Home Assistant until data is received.
+`binary_sensor` | Power switch sensor. 
 
 ![leafspy][leafspyimg]
 
@@ -40,6 +42,8 @@ custom_components/leafspy/__init__.py
 custom_components/leafspy/config_flow.py
 custom_components/leafspy/const.py
 custom_components/leafspy/device_tracker.py
+custom_components/leafspy/sensor.py
+custom_components/leafspy/binary_sensor.py
 custom_components/leafspy/manifest.json
 custom_components/leafspy/strings.json
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,18 @@ Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=leafspy)
   
-5. Configure your Leaf Spy app settings using the information that the integration displays on screen. If you don't have the app in front of you, copy down the password. The generated password will only be shown this once; if you don't copy it down, you'll have to uninstall the integration, restart, and reinstall.
+5. Configure your LeafSpy app settings using the information below, which will also be displayed on screen. If you don't have the app in front of you, copy down the password. The generated password will only be shown this once; if you don't copy it down, you'll have to uninstall the integration, restart, and reinstall. Open the LeafSpy app, go to `Menu` -> `Settings`.
+- In the **Units** section:
+  - Choose `°C`
+  - `Convert Outside Temperature`: `On`
+  - `CAN Odometer in Miles`: `On` if you see the option and if your car odometer displays in miles
+- In the **Server** section:
+  - `Enable`: `On`
+  - `Send Interval`: Whatever frequency you prefer
+  - `PW`: `<Displayed during configuration>`
+  - `Http://` or `Https://`: Depends on your Home Assistant installation
+  - `URL`: `<Displayed during configuration>`
+    - (**Do not** include the http or https prefix in the URL field.)
 
 ## Entities
 _See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Help-1.5.0.pdf#page=70) for more details on the data that the app sends._
@@ -43,24 +54,24 @@ _See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Hel
 ### Sensors
 | Entity ID | Unit reported by LeafSpy | Note |
 | :-- | :-- | :-- |
-| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app; see setup instructions.) | Unit adjustable in HA UI. |
+| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app; see instructions above.) | Unit adjustable in HA UI. |
 | sensor.leaf_battery_capacity | Ah | |
 | sensor.leaf_battery_conductance | % | Referred to as Hx in the LeafSpy manual. |
 | sensor.leaf_battery_current | A | |
 | sensor.leaf_battery_health | % | | 
 | sensor.leaf_battery_state_of_charge | % | |
 | sensor.leaf_battery_stat_of_charge_gids |  Gids | |
-| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app; see setup instructions.) | Unit adjustable in HA UI. |
+| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app; see instructions above.) | Unit adjustable in HA UI. |
 | sensor.leaf_battery_voltage | V | |
 | sensor.leaf_charge_mode | --- | |
 | sensor.leaf_charge_power | W | Not very accurate. For example, when charging via level 2 charging, it just guesses 6,000 W. |
 | sensor.leaf_elevation | m | Unit adjustable in HA UI |
 | sensor.leaf_front_wiper_status | --- | To get this information you may need to make a custom screen in LeafSpy to read wiper status. |
 | sensor.leaf_motor_speed | RPM | |
-| sensor.leaf_odometer | km (You must indicate in LeafSpy whether your car reports in km or mi; see setup instructions.) | Unit later adjustable in HA UI. |
+| sensor.leaf_odometer | km (You must indicate in LeafSpy if your displayed car odometer is in mi; see instructions above.) | Unit later adjustable in HA UI. |
 | sensor.leaf_phone_battery | % | |
 | sensor.leaf_plug_status | --- | Reports "Not plugged", "Partial Plugged", or "Plugged." |
-| sensor.leaf_sequence_number | --- | A number that increments with each report from Leaf Spy. |
+| sensor.leaf_sequence_number | --- | A number that increments with each report from LeafSpy. |
 | sensor.leaf_speed | km/h | Unit adjustable in HA UI. |
 | sensor.leaf_trip_number | --- | Tracks total number of trips taken. |
 | sensor.leaf_vin | ---  | Car unique identifier. | 

--- a/README.md
+++ b/README.md
@@ -43,25 +43,25 @@ _See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Hel
 ### Sensors
 | Entity ID | Unit reported by LeafSpy | Note |
 | :-- | :-- | :-- |
-| sensor.leaf_ambient_temperature | °C / °F | Unit adjustable in HA UI BUT ALSO... |
+| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI |
 | sensor.leaf_battery_capacity | Ah | |
-| sensor.leaf_battery_conductance | % | Referred to as Hx |
+| sensor.leaf_battery_conductance | % | Referred to as Hx in the LeafSpy manual |
 | sensor.leaf_battery_current | A | |
 | sensor.leaf_battery_gids |  Gids | |
 | sensor.leaf_battery_health | % | | 
 | sensor.leaf_battery_state_of_charge | % | |
-| sensor.leaf_battery_temperature | °C / °F | Unit adjustable in HA UI BUT ALSO... |
+| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI |
 | sensor.leaf_battery_voltage | V | |
 | sensor.leaf_charge_mode | --- | |
+| sensor.leaf_charge_power | W | Not very accurate. For example, when charging via level 2 charging, it just guesses 6,000 W. |
 | sensor.leaf_elevation | m | Unit adjustable in HA UI |
 | sensor.leaf_front_wiper | --- | Not known if Leaf Spy reports this. File an issue if you see info here. |
 | sensor.leaf_motor_speed | RPM | |
-| sensor.leaf_odometer | km | Unit adjustable in HA UI |
+| sensor.leaf_odometer | km | You must indicate in LeafSpy whether your car reports in km or mi. Unit adjustable in HA UI |
 | sensor.leaf_phone_battery | % | |
 | sensor.leaf_plug | --- | Reports "Not plugged", "Partial Plugged", or "Plugged" |
 | sensor.leaf_sequence_number | --- | A number that increments with each report from Leaf Spy |
 | sensor.leaf_speed | km/h | Unit adjustable in HA UI |
-| sensor.leaf_temperature_units | --- | Shows whether LeafSpy is set to C or F. [Maybe no need to expose?] |
 | sensor.leaf_trip_number | --- | Tracks total number of trips taken |
 | sensor.leaf_vin | ---  | Car unique identifier | 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# leafspy
+# LeafSpy integration for Home Assistant
 
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
@@ -7,79 +7,45 @@
 [![hacs][hacsbadge]][hacs]
 ![Project Maintenance][maintenance-shield]
 
-[![Discord][discord-shield]][discord]
-[![Community Forum][forum-shield]][forum]
+<p align="center"><img src="leafspy.png" width="64"></p>
 
-_Component to integrate with [leafspy][leafspy]._
+This Home Assistant component integrates with the LeafSpy [Android](https://play.google.com/store/apps/details?id=com.Turbo3.Leaf_Spy_Pro&hl=en_US) and [iOS](https://apps.apple.com/us/app/leafspy-pro/id967376861). Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product/B0755N61PW/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1)) into your Nissan Leaf. Open up LeafSpy and pair your phone with the adapter. It will then read information from your car. This integration will allow your phone to submit that info to Home Assistant.
 
-**This component will set up the following platforms.**
+## Installation and configuration
 
-Platform | Description
--- | --
-`device_tracker` | Track a Nissan Leaf using the Leaf Spy app. 
-`sensor` | All data about the vehicle sent from Leaf Spy is displayed as independent sensors. They won't appear in Home Assistant until data is received.
-`binary_sensor` | Power switch sensor. 
-
-![leafspy][leafspyimg]
-
-## Installation
+1. [Install HACS](https://www.hacs.xyz/docs/use/configuration/basic/).
+2. Add this to HACS as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) by pressing this button.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jesserockz&repository=ha-leafspy&category=integration)
 
-1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
-2. If you do not have a `custom_components` directory (folder) there, you need to create it.
-3. In the `custom_components` directory (folder) create a new folder called `leafspy`.
-4. Download _all_ the files from the `custom_components/leafspy/` directory (folder) in this repository.
-5. Place the files you downloaded in the new directory (folder) you created.
-6. Restart Home Assistant
-7. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "Leaf Spy"
+3. Restart Home Assistant
+4. In the UI go to "Configuration" -> "Integrations" click "+" and search for "Leaf Spy"
+5. Configure your Leaf Spy app using the information that the integration displays on screen. If you don't have the app in front of you, copy down the on-screen information; the generated password will only be shown this once. If you don't copy it down, you'll have to uninstall the integration, restart, and reinstall.
 
-Using your HA configuration directory (folder) as a starting point you should now also have this:
+## Entities
+_See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Help-1.5.0.pdf#page=70) for more details on the entities it sends._
 
-```text
-custom_components/leafspy/translations/en.json
-custom_components/leafspy/__init__.py
-custom_components/leafspy/config_flow.py
-custom_components/leafspy/const.py
-custom_components/leafspy/device_tracker.py
-custom_components/leafspy/sensor.py
-custom_components/leafspy/binary_sensor.py
-custom_components/leafspy/manifest.json
-custom_components/leafspy/strings.json
-```
+### Device tracker
+| Entity ID | Entity Name | Description |
+| :-- | :-: | :-- |
+| device_tracker.leaf | Leaf | Tracks latitude, longitude, GPS accuracy, and battery level |
 
-## Configuration is done in the UI
+### Binary sensor
+| Entity ID | Entity Name | Description |
+| :-- | :-: | :-- |
+| binary_sensor.leaf_power | Leaf power | Indicates whether car is turned on |
 
-### Android/iOS app configuration
+### Sensors
+| Entity ID | Entity Name | Description |
+| :-- | :-: | :-- |
+| sensor.leaf_ambient_temperature | Leaf ambient temperature | Indicates temperature outside of car |
+| sensor.leaf_battery_capacity | Leaf battery capacity | Indicates battery capacity (Ah) |
+| ... | ... | ... |
 
-Open the Leaf Spy app, go to `Menu` -> `Settings` and scroll down to `Server`. 
-Change the following settings:
-- `Enable`: Yes
-- `Send Interval` can be whatever you prefer.
-- `ID`: `<Car Name>`
-- `PW`: secret generated when the integration was installed
-- `Http` or `Https` depending on the access to your Home Assistant install.
-- `URL`: webhook url generated when the integration was installed 
-  - Note: **Do not** add http or https to the URL.
-
-<!---->
-
-## Contributions are welcome!
-
-If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
-
-***
-
-[leafspy]: https://play.google.com/store/apps/details?id=com.Turbo3.Leaf_Spy_Pro
 [commits-shield]: https://img.shields.io/github/commit-activity/y/jesserockz/ha-leafspy.svg?style=for-the-badge
 [commits]: https://github.com/jesserockz/ha-leafspy/commits/main
 [hacs]: https://github.com/custom-components/hacs
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
-[discord]: https://discord.gg/Qa5fW2R
-[discord-shield]: https://img.shields.io/discord/330944238910963714.svg?style=for-the-badge
-[leafspyimg]: leafspy.png
-[forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
-[forum]: https://community.home-assistant.io/
 [license-shield]: https://img.shields.io/github/license/jesserockz/ha-leafspy.svg?style=for-the-badge
 [maintenance-shield]: https://img.shields.io/badge/maintainer-Will%20Adler%20%40wtadler-blue.svg?style=for-the-badge
 [releases-shield]: https://img.shields.io/github/release/jesserockz/ha-leafspy.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -43,21 +43,21 @@ _See [LeafSpy manual](https://leafspy.com/wp-content/uploads/2024/04/LeafSpy-Hel
 ### Sensors
 | Entity ID | Unit reported by LeafSpy | Note |
 | :-- | :-- | :-- |
-| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI. |
+| sensor.leaf_ambient_temperature | °C (You must set this in the LeafSpy app; see setup instructions.) | Unit adjustable in HA UI. |
 | sensor.leaf_battery_capacity | Ah | |
 | sensor.leaf_battery_conductance | % | Referred to as Hx in the LeafSpy manual. |
 | sensor.leaf_battery_current | A | |
 | sensor.leaf_battery_health | % | | 
 | sensor.leaf_battery_state_of_charge | % | |
 | sensor.leaf_battery_stat_of_charge_gids |  Gids | |
-| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app) | Unit adjustable in HA UI. |
+| sensor.leaf_battery_temperature | °C (You must set this in the LeafSpy app; see setup instructions.) | Unit adjustable in HA UI. |
 | sensor.leaf_battery_voltage | V | |
 | sensor.leaf_charge_mode | --- | |
 | sensor.leaf_charge_power | W | Not very accurate. For example, when charging via level 2 charging, it just guesses 6,000 W. |
 | sensor.leaf_elevation | m | Unit adjustable in HA UI |
 | sensor.leaf_front_wiper_status | --- | To get this information you may need to make a custom screen in LeafSpy to read wiper status. |
 | sensor.leaf_motor_speed | RPM | |
-| sensor.leaf_odometer | km | You must indicate _in LeafSpy_ whether your car reports in km or mi. Unit later adjustable in HA UI. |
+| sensor.leaf_odometer | km (You must indicate in LeafSpy whether your car reports in km or mi; see setup instructions.) | Unit later adjustable in HA UI. |
 | sensor.leaf_phone_battery | % | |
 | sensor.leaf_plug_status | --- | Reports "Not plugged", "Partial Plugged", or "Plugged." |
 | sensor.leaf_sequence_number | --- | A number that increments with each report from Leaf Spy. |

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Plug a Bluetooth OBD2 adapter (like [this one](https://www.amazon.com/gp/product
 - In the **Server** section:
   - `Enable`: `On`
   - `Send Interval`: Whatever frequency you prefer
-  - `PW`: `<Displayed during configuration>`
+  - `PW`: `<Generated and displayed during setup>`
   - `Http://` or `Https://`: Depends on your Home Assistant installation
-  - `URL`: `<Displayed during configuration>`
+  - `URL`: `<Displayed during setup>`
     - (**Do not** include the http or https prefix in the URL field.)
 
 ## Entities

--- a/custom_components/leafspy/__init__.py
+++ b/custom_components/leafspy/__init__.py
@@ -19,7 +19,7 @@ from .device_tracker import async_handle_message
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["device_tracker"]
+PLATFORMS = ["device_tracker", "sensor", "binary_sensor"]
 
 # Use empty_config_schema because the component does not have any config options
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
@@ -28,6 +28,7 @@ async def async_setup(hass, config):
     """Initialize Leaf Spy component."""
     hass.data[DOMAIN] = {
         'devices': {},
+        'sensors': {},
         'unsub': None,
     }
     return True
@@ -44,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.http.register_view(LeafSpyView())
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
+    
     hass.data[DOMAIN]['unsub'] = \
         async_dispatcher_connect(hass, DOMAIN, async_handle_message)
 

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -33,7 +33,6 @@ BINARY_SENSOR_TYPES = [
         device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda data: data.get("PwrSw"),
         transform_fn=lambda x: x == '1',
-        icon="mdi:power",
     )
 ]
 

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -33,6 +33,7 @@ BINARY_SENSOR_TYPES = [
         device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda data: data.get("PwrSw"),
         transform_fn=lambda x: x == '1',
+        icon="mdi:power",
     )
 ]
 

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -154,11 +154,13 @@ class LeafSpyBinarySensor(BinarySensorEntity, RestoreEntity):
         await super().async_added_to_hass()
         
         last_state = await self.async_get_last_state()
-        if last_state:
-            try:
-                self._value = last_state.state
-            except (ValueError, TypeError):
-                _LOGGER.warning(f"Could not restore state for {self.name}")
+        _LOGGER.debug(f"Last_state: {last_state}")
+
+        # if last_state:
+        #     try:
+        #         self._value = last_state.state
+        #     except (ValueError, TypeError):
+        #         _LOGGER.warning(f"Could not restore state for {self.name}")
         
         # Add this log line to confirm the method is being called
         _LOGGER.debug(f"async_added_to_hass called for {self.name}")

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -1,0 +1,129 @@
+"""Binary sensor platform that adds support for Leaf Spy."""
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+@dataclass(frozen=True)
+class LeafSpyBinarySensorDescription(BinarySensorEntityDescription):
+    """Describes Leaf Spy binary sensor."""
+    value_fn: Callable[[dict], Any] = field(default=lambda data: None)
+    transform_fn: Callable[[Any], bool] = field(default=lambda x: bool(x))
+
+BINARY_SENSOR_TYPES = [
+    LeafSpyBinarySensorDescription(
+        key="power switch",
+        translation_key="power_switch_state",
+        device_class=BinarySensorDeviceClass.POWER,
+        value_fn=lambda data: data.get("PwrSw"),
+        transform_fn=lambda x: x == 1,
+        icon="mdi:power",
+    )
+]
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None
+) -> bool:
+    """Set up Leaf Spy binary sensors based on a config entry."""
+    if 'binary_sensors' not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]['binary_sensors'] = {}
+
+    async def _process_message(context, message):
+        """Process incoming sensor messages."""
+        try:
+            _LOGGER.debug("Incoming message: %s", message)
+            if 'VIN' not in message:
+                return
+
+            dev_id = slugify(f'leaf_{message["VIN"]}')
+
+            # Create and update binary sensors for each description
+            for description in BINARY_SENSOR_TYPES:
+                sensor_id = f"{dev_id}_{description.key}"
+                value = description.value_fn(message)
+                _LOGGER.debug("Binary Sensor '%s': Raw data=%s, Parsed value=%s", description.key, message, value)
+
+                value = description.transform_fn(value)
+                _LOGGER.debug("Binary Sensor '%s': Transformed value=%s", description.key, value)
+
+                if value is not None:
+                    sensor = hass.data[DOMAIN]['binary_sensors'].get(sensor_id)
+                    if sensor is not None:
+                        sensor.update_state(value)
+                    else:
+                        sensor = LeafSpyBinarySensor(dev_id, description, value)
+                        hass.data[DOMAIN]['binary_sensors'][sensor_id] = sensor
+                        async_add_entities([sensor])
+
+        except Exception as err:
+            _LOGGER.error("Error processing Leaf Spy message: %s", err)
+
+    async_dispatcher_connect(hass, DOMAIN, _process_message)
+    return True
+
+
+class LeafSpyBinarySensor(BinarySensorEntity, RestoreEntity):
+    """Representation of a Leaf Spy binary sensor."""
+
+    def __init__(self, device_id: str, description: LeafSpyBinarySensorDescription, initial_value):
+        """Initialize the binary sensor."""
+        self._device_id = device_id
+        self._value = initial_value
+        self.entity_description = description
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._device_id}_{self.entity_description.key}"
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor."""
+        return f"Leaf {self.entity_description.key}"
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        return self._value
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+        }
+
+    def update_state(self, new_value):
+        """Update the binary sensor state."""
+        self._value = new_value
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Restore last known state."""
+        await super().async_added_to_hass()
+        
+        last_state = await self.async_get_last_state()
+        if last_state:
+            try:
+                transform_fn = self.entity_description.transform_fn
+                self._value = transform_fn(last_state.state)
+            except (ValueError, TypeError):
+                _LOGGER.warning(f"Could not restore state for {self.name}")

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -127,6 +127,7 @@ class LeafSpyBinarySensor(BinarySensorEntity, RestoreEntity):
     def device_info(self):
         """Return device information."""
         return {
+            "name": "Leaf",
             "identifiers": {(DOMAIN, self._device_id)},
         }
     

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -24,11 +24,12 @@ _LOGGER = logging.getLogger(__name__)
 class LeafSpyBinarySensorDescription(BinarySensorEntityDescription):
     """Describes Leaf Spy binary sensor."""
     transform_fn: Callable[[dict], Any] = field(default=lambda x: x)
+    leafspy_key: str = field(default=None)
 
 BINARY_SENSOR_TYPES = [
     LeafSpyBinarySensorDescription(
         key="power",
-        translation_key="PwrSw",
+        leafspy_key="PwrSw",
         device_class=BinarySensorDeviceClass.POWER,
         transform_fn=lambda x: x == '1',
         icon="mdi:power",
@@ -58,7 +59,7 @@ async def async_setup_entry(
             for description in BINARY_SENSOR_TYPES:
                 sensor_id = f"{dev_id}_{description.key}"
                 # value = description.value_fn(message)
-                value = message.get(description.translation_key, None)
+                value = message.get(description.leafspy_key, None)
                 _LOGGER.debug(f"Binary sensor {description.key}: Initial value={value}")
 
                 if description.transform_fn:
@@ -124,6 +125,11 @@ class LeafSpyBinarySensor(BinarySensorEntity, RestoreEntity):
     def unique_id(self):
         """Return a unique ID."""
         return f"{self._device_id}_{self.entity_description.key}"
+
+    @property
+    def translation_key(self):
+        """Return the translation key."""
+        return self.entity_description.key
 
     @property
     def is_on(self):

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -31,7 +31,7 @@ BINARY_SENSOR_TYPES = [
         translation_key="power_switch_state",
         device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda data: data.get("PwrSw"),
-        transform_fn=lambda x: x == 1,
+        transform_fn=lambda x: x == '1',
         icon="mdi:power",
     )
 ]

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -93,12 +93,14 @@ async def async_setup_entry(
 
     entities = []
     for dev_id in dev_ids:
-        entity = hass.data[DOMAIN]['binary_sensors'].get(dev_id)
-        if entity is None:
-            entity = LeafSpyBinarySensor(dev_id, BINARY_SENSOR_TYPES[0], False)
-            entities.append(entity)
-        async_add_entities(entities)
 
+        # For each device ID, recreate the sensor entities
+        for description in BINARY_SENSOR_TYPES:
+            sensor_id = f"{dev_id}_{description.key}"
+            sensor = LeafSpyBinarySensor(dev_id, description, False)
+            hass.data[DOMAIN]['binary_sensors'][sensor_id] = sensor
+            entities.append(sensor)
+    async_add_entities(entities)
     return True
 
 
@@ -132,6 +134,12 @@ class LeafSpyBinarySensor(BinarySensorEntity, RestoreEntity):
         return {
             "identifiers": {(DOMAIN, self._device_id)},
         }
+    
+    @property
+    def should_poll(self) -> bool:
+        """Disable polling for this sensor."""
+        return False
+
 
     def update_state(self, new_value):
         """Update the binary sensor state."""

--- a/custom_components/leafspy/binary_sensor.py
+++ b/custom_components/leafspy/binary_sensor.py
@@ -28,8 +28,8 @@ class LeafSpyBinarySensorDescription(BinarySensorEntityDescription):
 
 BINARY_SENSOR_TYPES = [
     LeafSpyBinarySensorDescription(
-        key="power switch",
-        translation_key="power_switch_state",
+        key="power",
+        translation_key="power",
         device_class=BinarySensorDeviceClass.POWER,
         value_fn=lambda data: data.get("PwrSw"),
         transform_fn=lambda x: x == '1',

--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -28,7 +28,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             entity.update_data(data)
             return
 
-        entity = hass.data[LS_DOMAIN]['devices'][dev_id] = LeafSpyEntity(
+        entity = hass.data[LS_DOMAIN]['devices'][dev_id] = LeafSpyDeviceTracker(
             dev_id, data
         )
         async_add_entities([entity])
@@ -49,7 +49,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     entities = []
     for dev_id in dev_ids:
-        entity = hass.data[LS_DOMAIN]['devices'][dev_id] = LeafSpyEntity(
+        entity = hass.data[LS_DOMAIN]['devices'][dev_id] = LeafSpyDeviceTracker(
             dev_id
         )
         entities.append(entity)
@@ -57,14 +57,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities)
 
 
-class LeafSpyEntity(TrackerEntity, RestoreEntity):
+class LeafSpyDeviceTracker(TrackerEntity, RestoreEntity):
     """Represent a tracked car."""
 
     def __init__(self, dev_id, data=None):
         """Set up LeafSpy entity."""
         self._dev_id = dev_id
         self._data = data or {}
-        self.entity_id = f"{LS_DOMAIN}.{dev_id}"
+        # self.entity_id = f"{LS_DOMAIN}.{dev_id}"
+        self.entity_id = f"{LS_DOMAIN}.leaf"
 
     @property
     def unique_id(self):

--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -18,20 +18,6 @@ from .const import DOMAIN as LS_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLUG_STATES = [
-    "Not Plugged In",
-    "Partially Plugged In",
-    "Plugged In"
-]
-
-CHARGE_MODES = [
-    "Not Charging",
-    "Level 1 Charging (100-120 Volts)",
-    "Level 2 Charging (200-240 Volts)",
-    "Level 3 Quick Charging"
-]
-
-
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up Leaf Spy based off an entry."""
     async def _receive_data(dev_id, **data):
@@ -91,11 +77,6 @@ class LeafSpyEntity(TrackerEntity, RestoreEntity):
         return self._data.get('battery_level')
 
     @property
-    def extra_state_attributes(self):
-        """Return extra attributes."""
-        return self._data.get('attributes')
-
-    @property
     def latitude(self):
         """Return latitude value of the car."""
         return self._data.get('latitude')
@@ -147,8 +128,6 @@ class LeafSpyEntity(TrackerEntity, RestoreEntity):
             'latitude': attr.get(ATTR_LATITUDE),
             'longitude': attr.get(ATTR_LONGITUDE),
             'battery_level': attr.get(ATTR_BATTERY_LEVEL),
-            'attributes': attr
-
         }
 
     @callback
@@ -166,25 +145,7 @@ def _parse_see_args(message):
         'device_name': message['user'],
         'latitude': float(message['Lat']),
         'longitude': float(message['Long']),
-        'battery_level': float(message['SOC']),
-        'attributes': {
-            'amp_hours': float(message['AHr']),
-            'trip': int(message['Trip']),
-            'odometer': float(message['Odo']),
-            'battery_temperature': float(message['BatTemp']),
-            'battery_health': float(message['SOH']),
-            'outside_temperature': float(message['Amb']),
-            'plug_state': PLUG_STATES[int(message['PlugState'])],
-            'charge_mode': CHARGE_MODES[int(message['ChrgMode'])],
-            'charge_power': int(message['ChrgPwr']),
-            'vin': message['VIN'],
-            'power_switch': message['PwrSw'] == '1',
-            'device_battery': int(message['DevBat']),
-            'rpm': int(message['RPM']),
-            'gids': int(message['Gids']),
-            'elevation': float(message['Elv']),
-            'sequence': int(message['Seq'])
-        }
+        'battery_level': float(message['SOC'])
     }
 
     return args

--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -64,8 +64,6 @@ class LeafSpyDeviceTracker(TrackerEntity, RestoreEntity):
         """Set up LeafSpy entity."""
         self._dev_id = dev_id
         self._data = data or {}
-        # self.entity_id = f"{LS_DOMAIN}.{dev_id}"
-        self.entity_id = f"{LS_DOMAIN}.leaf"
 
     @property
     def unique_id(self):
@@ -95,7 +93,7 @@ class LeafSpyDeviceTracker(TrackerEntity, RestoreEntity):
     @property
     def name(self):
         """Return the name of the car."""
-        return self._data.get('device_name')
+        return 'Leaf'
 
     @property
     def should_poll(self):
@@ -148,7 +146,6 @@ def _parse_see_args(message):
     dev_id = slugify('leaf_{}'.format(message['VIN']))
     args = {
         'dev_id': dev_id,
-        'device_name': message['user'],
         'latitude': float(message['Lat']),
         'longitude': float(message['Long']),
         'battery_level': float(message['SOC'])

--- a/custom_components/leafspy/device_tracker.py
+++ b/custom_components/leafspy/device_tracker.py
@@ -75,6 +75,11 @@ class LeafSpyEntity(TrackerEntity, RestoreEntity):
     def battery_level(self):
         """Return the battery level of the car."""
         return self._data.get('battery_level')
+        
+    @property
+    def icon(self):
+        """Return the icon for the device."""
+        return 'mdi:car'
 
     @property
     def latitude(self):
@@ -105,7 +110,7 @@ class LeafSpyEntity(TrackerEntity, RestoreEntity):
     def device_info(self):
         """Return the device info."""
         return {
-            'name': self.name,
+            'name': 'Leaf',
             'identifiers': {(LS_DOMAIN, self._dev_id)},
         }
 

--- a/custom_components/leafspy/manifest.json
+++ b/custom_components/leafspy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/jesserockz/ha-leafspy/issues",
   "requirements": [],
-  "version": "0.2.4"
+  "version": "0.3.0"
 }

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 class LeafSpySensorDescription(SensorEntityDescription):
     """Describes Leaf Spy sensor."""
     transform_fn: Callable[[dict], Any] = field(default=lambda x: x)
+    leafspy_key: str = field(default=None)
 
 def _safe_round(x, digits=2):
     try:
@@ -58,21 +59,21 @@ def _transform_hx(x):
 SENSOR_TYPES = [
     LeafSpySensorDescription(
         key="phone_battery",
-        translation_key="DevBat",
+        leafspy_key="DevBat",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LeafSpySensorDescription(
         key="battery_gids",
-        translation_key="Gids",
+        leafspy_key="Gids",
         native_unit_of_measurement="Gids",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:battery",
     ),
     LeafSpySensorDescription(
         key="elevation",
-        translation_key="Elv",
+        leafspy_key="Elv",
         native_unit_of_measurement=UnitOfLength.METERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -81,26 +82,26 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="sequence_number",
-        translation_key="Seq",
+        leafspy_key="Seq",
         icon="mdi:numeric",
     ),
     LeafSpySensorDescription(
         key="trip_number",
-        translation_key="Trip",
+        leafspy_key="Trip",
         icon="mdi:road-variant",
     ),
     LeafSpySensorDescription(
         key="odometer",
-        translation_key="Odo",
+        leafspy_key="Odo",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        transform_fn=lambda x: _safe_round(x, 0),
+        transform_fn=lambda x: _safe_round(x, 1),
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(
         key="battery_state_of_charge",
-        translation_key="SOC",
+        leafspy_key="SOC",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
@@ -108,7 +109,7 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="battery_capacity",
-        translation_key="Ahr",
+        leafspy_key="AHr",
         state_class=SensorStateClass.MEASUREMENT,
         transform_fn=lambda x: _safe_round(x, 2),
         native_unit_of_measurement="Ah",
@@ -116,14 +117,14 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="battery_temperature",
-        translation_key="BatTemp",
+        leafspy_key="BatTemp",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LeafSpySensorDescription(
         key="ambient_temperature",
-        translation_key="Amb",
+        leafspy_key="Amb",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -131,14 +132,14 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="charge_power",
-        translation_key="ChrgPwr",
+        leafspy_key="ChrgPwr",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LeafSpySensorDescription(
         key="front_wiper",
-        translation_key="Wpr",
+        leafspy_key="Wpr",
         device_class=SensorDeviceClass.ENUM,
         transform_fn=lambda x: {
             80: "High",
@@ -159,7 +160,7 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="plug_state",
-        translation_key="PlugState",
+        leafspy_key="PlugState",
         device_class=SensorDeviceClass.ENUM,
         transform_fn=lambda x: {
             0: "Not plugged",
@@ -176,7 +177,7 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="charge_mode",
-        translation_key="ChrgMode",
+        leafspy_key="ChrgMode",
         device_class=SensorDeviceClass.ENUM,
         transform_fn=lambda x: {
             0: "Not charging",
@@ -194,27 +195,27 @@ SENSOR_TYPES = [
         ]
     ),
     LeafSpySensorDescription(
-        key="VIN",
-        translation_key="VIN",
+        key="vin",
+        leafspy_key="VIN",
         icon="mdi:identifier",
     ),
     LeafSpySensorDescription(
         key="motor_speed",
-        translation_key="RPM",
+        leafspy_key="RPM",
         native_unit_of_measurement="RPM",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:engine",
     ),
     LeafSpySensorDescription(
         key="battery_health",
-        translation_key="SOH",
+        leafspy_key="SOH",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
         key="battery_conductance",
-        translation_key="Hx",
+        leafspy_key="Hx",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         transform_fn=lambda x: _safe_round(_transform_hx(x), 2),
@@ -222,14 +223,14 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="speed",
-        translation_key="Speed",
+        leafspy_key="Speed",
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LeafSpySensorDescription(
         key="battery_voltage",
-        translation_key="BatVolts",
+        leafspy_key="BatVolts",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -237,7 +238,7 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="battery_current",
-        translation_key="BatAmps",
+        leafspy_key="BatAmps",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -267,7 +268,7 @@ async def async_setup_entry(
             # Create and update sensors for each description
             for description in SENSOR_TYPES:
                 sensor_id = f"{dev_id}_{description.key}"
-                value = message.get(description.translation_key, None)
+                value = message.get(description.leafspy_key, None)
 
                 _LOGGER.debug(f"Sensor {description.key}: Initial value={value}")
 
@@ -340,11 +341,10 @@ class LeafSpySensor(RestoreSensor):
         """Return a unique ID."""
         return f"{self._device_id}_{self.entity_description.key}"
 
-
     @property
     def translation_key(self):
         """Return the translation key."""
-        return self.entity_description.translation_key
+        return self.entity_description.key
     
     @property
     def native_value(self):

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -194,7 +194,7 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        transform_fn=lambda x: _safe_round(x, 1),
+        transform_fn=lambda x: _safe_round(x, 0),
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -48,15 +48,15 @@ def _get_temperature_unit(data):
 SENSOR_TYPES = [
     LeafSpySensorDescription(
         key="phone battery",
-        translation_key="device_battery",
+        translation_key="phone_battery",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("DevBat"),
     ),
     LeafSpySensorDescription(
-        key="Gids",
-        translation_key="gids",
+        key="battery gids",
+        translation_key="battery_gids",
         native_unit_of_measurement="Gids",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("Gids"),
@@ -73,7 +73,7 @@ SENSOR_TYPES = [
         icon="mdi:elevation-rise",
     ),
     LeafSpySensorDescription(
-        key="sequence",
+        key="sequence number",
         translation_key="sequence_number",
         value_fn=lambda data: data.get("Seq"),
         icon="mdi:numeric",
@@ -85,7 +85,7 @@ SENSOR_TYPES = [
         icon="mdi:road-variant",
     ),
     LeafSpySensorDescription(
-        key="mileage",
+        key="odometer",
         translation_key="odometer",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
@@ -95,7 +95,7 @@ SENSOR_TYPES = [
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(
-        key="battery level (SOC)",
+        key="battery state of charge",
         translation_key="state_of_charge",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
@@ -104,11 +104,12 @@ SENSOR_TYPES = [
         transform_fn=lambda x: int(round(float(x), 0)) if x is not None else None,
     ),
     LeafSpySensorDescription(
-        key="capacity (AHr)",
-        translation_key="AHr_capacity",
+        key="battery capacity",
+        translation_key="battery_capacity",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("AHr"),
         transform_fn=lambda x: float(x) if x is not None else None,
+        native_unit_of_measurement="Ah",
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
@@ -140,11 +141,10 @@ SENSOR_TYPES = [
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("ChrgPwr"),
-        icon="mdi:lightning-bolt",
     ),
     LeafSpySensorDescription(
         key="front wiper",
-        translation_key="front_wiper_status",
+        translation_key="front_wiper",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: {
             80: "High",
@@ -164,8 +164,8 @@ SENSOR_TYPES = [
         ]
     ),
     LeafSpySensorDescription(
-        key="plug state",
-        translation_key="plug_state",
+        key="plug",
+        translation_key="plug",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: {
             0: "Not plugged",
@@ -201,7 +201,7 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="VIN",
-        translation_key="vehicle_identification_number",
+        translation_key="VIN",
         value_fn=lambda data: data.get("VIN"),
         icon="mdi:identifier",
     ),
@@ -212,16 +212,16 @@ SENSOR_TYPES = [
         icon="mdi:temperature-celsius",
     ),
     LeafSpySensorDescription(
-        key="motor rpm",
-        translation_key="motor_rpm",
+        key="motor speed",
+        translation_key="motor_speed",
         native_unit_of_measurement="RPM",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("RPM"),
         icon="mdi:engine",
     ),
     LeafSpySensorDescription(
-        key="battery health (SOH)",
-        translation_key="state_of_health",
+        key="battery health",
+        translation_key="battery_health",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("SOH"),
@@ -229,16 +229,16 @@ SENSOR_TYPES = [
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
-        key="Hx",
-        translation_key="hx_value",
-        native_unit_of_measurement=PERCENTAGE,
+        key="battery conductance",
+        translation_key="battery_conductance",
+        native_unit_of_measurement='Hx',
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("Hx"),
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
         key="speed",
-        translation_key="vehicle_speed",
+        translation_key="speed",
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -1,0 +1,365 @@
+"""Sensor platform that adds support for Leaf Spy."""
+import logging
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfLength,
+    UnitOfPower,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+@dataclass(frozen=True)
+class LeafSpySensorDescription(SensorEntityDescription):
+    """Describes Leaf Spy sensor."""
+    value_fn: Callable[[dict], Any] = field(default=lambda data: None)
+    transform_fn: Callable[[Any], Any] = field(default=lambda x: x)
+    unit_fn: Callable[[dict], str] = field(default=lambda data: None)
+
+def _get_temperature_unit(data):
+    """Determine the temperature unit based on Tunits."""
+    tunits = data.get("Tunits", "").lower()
+    if tunits == "f":
+        return UnitOfTemperature.FAHRENHEIT
+    return UnitOfTemperature.CELSIUS
+
+SENSOR_TYPES = [
+    LeafSpySensorDescription(
+        key="phone battery",
+        translation_key="device_battery",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("DevBat"),
+    ),
+    LeafSpySensorDescription(
+        key="Gids",
+        translation_key="gids",
+        native_unit_of_measurement="Gids",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("Gids"),
+        icon="mdi:battery",
+    ),
+    LeafSpySensorDescription(
+        key="elevation",
+        translation_key="elevation",
+        native_unit_of_measurement=UnitOfLength.METERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("Elv"),
+        transform_fn=lambda x: int(round(float(x), 0)) if x is not None else None,
+        icon="mdi:elevation-rise",
+    ),
+    LeafSpySensorDescription(
+        key="sequence",
+        translation_key="sequence_number",
+        value_fn=lambda data: data.get("Seq"),
+        icon="mdi:numeric",
+    ),
+    LeafSpySensorDescription(
+        key="trip number",
+        translation_key="trip_number",
+        value_fn=lambda data: data.get("Trip"),
+        icon="mdi:road-variant",
+    ),
+    LeafSpySensorDescription(
+        key="mileage",
+        translation_key="odometer",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.get("Odo"),
+        transform_fn=lambda x: int(float(x)) if x is not None else None,
+        icon="mdi:counter",
+    ),
+    LeafSpySensorDescription(
+        key="battery level (SOC)",
+        translation_key="state_of_charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("SOC"),
+        transform_fn=lambda x: int(round(float(x), 0)) if x is not None else None,
+    ),
+    LeafSpySensorDescription(
+        key="capacity (AHr)",
+        translation_key="AHr_capacity",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("AHr"),
+        transform_fn=lambda x: float(x) if x is not None else None,
+        icon="mdi:battery-heart-variant",
+    ),
+    LeafSpySensorDescription(
+        key="battery temperature",
+        translation_key="battery_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("BatTemp"),
+        transform_fn=lambda x: float(x) if x is not None else None,
+        unit_fn=_get_temperature_unit,
+        icon="mdi:thermometer",
+    ),
+    LeafSpySensorDescription(
+        key="ambient temperature",
+        translation_key="ambient_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("Amb"),
+        transform_fn=lambda x: float(x) if x is not None else None,
+        unit_fn=_get_temperature_unit,
+        icon="mdi:sun-thermometer",
+    ),
+    LeafSpySensorDescription(
+        key="charge power",
+        translation_key="charge_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("ChrgPwr"),
+        icon="mdi:lightning-bolt",
+    ),
+    LeafSpySensorDescription(
+        key="front wiper",
+        translation_key="front_wiper_status",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda data: {
+            80: "High",
+            40: "Low",
+            20: "Switch",
+            10: "Intermittent",
+            8: "Stopped"
+        }.get(int(data.get("Wpr")), "unknown"),
+        icon="mdi:wiper",
+        options=[
+            "High",
+            "Low",
+            "Switch",
+            "Intermittent",
+            "Stopped",
+            "unknown"
+        ]
+    ),
+    LeafSpySensorDescription(
+        key="plug state",
+        translation_key="plug_state",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda data: {
+            0: "Not plugged",
+            1: "Partial plugged",
+            2: "Plugged"
+        }.get(int(data.get("PlugState")), "unknown"),
+        icon="mdi:power-plug",
+        options=[
+            "Not plugged",
+            "Partial plugged",
+            "Plugged",
+            "unknown"
+        ]
+    ),
+    LeafSpySensorDescription(
+        key="charge mode",
+        translation_key="charge_mode",
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda data: {
+            0: "Not charging",
+            1: "Level 1 charging",
+            2: "Level 2 charging",
+            3: "Level 3 quick charging"
+        }.get(int(data.get("ChrgMode")), "unknown"),
+        icon="mdi:battery-charging-wireless",
+        options=[
+            "Not charging",
+            "Level 1 charging",
+            "Level 2 charging", 
+            "Level 3 quick charging",
+            "unknown"
+        ]
+    ),
+    LeafSpySensorDescription(
+        key="VIN",
+        translation_key="vehicle_identification_number",
+        value_fn=lambda data: data.get("VIN"),
+        icon="mdi:identifier",
+    ),
+    LeafSpySensorDescription(
+        key="temperature units",
+        translation_key="temperature_units",
+        value_fn=lambda data: data.get("Tunits"),
+        icon="mdi:temperature-celsius",
+    ),
+    LeafSpySensorDescription(
+        key="motor rpm",
+        translation_key="motor_rpm",
+        native_unit_of_measurement="RPM",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("RPM"),
+        icon="mdi:engine",
+    ),
+    LeafSpySensorDescription(
+        key="battery health (SOH)",
+        translation_key="state_of_health",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("SOH"),
+        transform_fn=lambda x: float(x) if x is not None else None,
+        icon="mdi:battery-heart-variant",
+    ),
+    LeafSpySensorDescription(
+        key="Hx",
+        translation_key="hx_value",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("Hx"),
+        icon="mdi:battery-heart-variant",
+    ),
+    LeafSpySensorDescription(
+        key="speed",
+        translation_key="vehicle_speed",
+        native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
+        device_class=SensorDeviceClass.SPEED,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("Speed"),
+    ),
+    LeafSpySensorDescription(
+        key="battery voltage",
+        translation_key="battery_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("BatVolts"),
+    ),
+    LeafSpySensorDescription(
+        key="battery current",
+        translation_key="battery_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get("BatAmps"),
+    ),
+]
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None
+) -> bool:
+    """Set up Leaf Spy sensors based on a config entry."""
+    if 'sensors' not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]['sensors'] = {}
+
+    async def _process_message(context, message):
+        """Process incoming sensor messages."""
+        try:
+            if 'VIN' not in message:
+                return
+
+            dev_id = slugify(f'leaf_{message["VIN"]}')
+
+            # Create and update sensors for each description
+            for description in SENSOR_TYPES:
+                sensor_id = f"{dev_id}_{description.key}"
+                value = description.value_fn(message)
+                _LOGGER.debug("Sensor '%s': Raw data=%s, Parsed value=%s", description.key, message, value)
+
+                value = description.transform_fn(value)
+                _LOGGER.debug("Sensor '%s': Transformed value=%s", description.key, value)
+
+                if value is not None:
+                    sensor = hass.data[DOMAIN]['sensors'].get(sensor_id)
+                    
+                    # Dynamically update temperature unit if applicable
+                    sensor_description = description
+                    if description.unit_fn:
+                        unit = description.unit_fn(message)
+                        if unit:
+                            sensor_description = replace(description, 
+                                native_unit_of_measurement=unit)
+
+                    if sensor is not None:
+                        # Update with potentially new unit
+                        sensor.entity_description = sensor_description
+                        sensor.update_state(value)
+                    else:
+                        sensor = LeafSpySensor(dev_id, sensor_description, value)
+                        hass.data[DOMAIN]['sensors'][sensor_id] = sensor
+                        async_add_entities([sensor])
+
+        except Exception as err:
+            _LOGGER.error("Error processing Leaf Spy message: %s", err)
+            _LOGGER.exception("Full traceback")
+
+    async_dispatcher_connect(hass, DOMAIN, _process_message)
+    return True
+
+
+class LeafSpySensor(SensorEntity, RestoreEntity):
+    """Representation of a Leaf Spy sensor."""
+
+    def __init__(self, device_id: str, description: LeafSpySensorDescription, initial_value):
+        """Initialize the sensor."""
+        self._device_id = device_id
+        self._value = initial_value
+        self.entity_description = description
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return f"{self._device_id}_{self.entity_description.key}"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return f"Leaf {self.entity_description.key}"
+
+    @property
+    def native_value(self):
+        """Return the sensor's value."""
+        return self._value
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+        }
+
+    def update_state(self, new_value):
+        """Update the sensor state."""
+        self._value = new_value
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self):
+        """Restore last known state."""
+        await super().async_added_to_hass()
+        
+        last_state = await self.async_get_last_state()
+        if last_state:
+            try:
+                transform_fn = self.entity_description.transform_fn
+                self._value = transform_fn(last_state.state)
+            except (ValueError, TypeError):
+                _LOGGER.warning(f"Could not restore state for {self.name}")

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -33,20 +33,22 @@ _LOGGER = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class LeafSpySensorDescription(SensorEntityDescription):
     """Describes Leaf Spy sensor."""
-    value_fn: Callable[[dict], Any] = field(default=lambda data: None)
+    transform_fn: Callable[[dict], Any] = field(default=lambda x: x)
 
 def _safe_round(x, digits=2):
     try:
+        x = float(x)
         if digits==0:
-            return int(float(x))
+            return int(x)
         else:
-            return round(float(x), digits)
+            return round(x, digits)
     except (ValueError, TypeError):
         return None
     
 def _transform_hx(x):
     # if x > 100, divide by 102.4, otherwise return
     # takes care of iOS LeafSpy bug until patched
+    x = float(x)
     if x > 100:
         return x / 102.4
     else:
@@ -60,14 +62,12 @@ SENSOR_TYPES = [
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("DevBat"),
     ),
     LeafSpySensorDescription(
         key="battery_gids",
         translation_key="Gids",
         native_unit_of_measurement="Gids",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("Gids"),
         icon="mdi:battery",
     ),
     LeafSpySensorDescription(
@@ -76,19 +76,17 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfLength.METERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: _safe_round(data.get("Elv"), 2),
+        transform_fn=lambda x: _safe_round(x, 2),
         icon="mdi:elevation-rise",
     ),
     LeafSpySensorDescription(
         key="sequence_number",
         translation_key="Seq",
-        value_fn=lambda data: data.get("Seq"),
         icon="mdi:numeric",
     ),
     LeafSpySensorDescription(
         key="trip_number",
         translation_key="Trip",
-        value_fn=lambda data: data.get("Trip"),
         icon="mdi:road-variant",
     ),
     LeafSpySensorDescription(
@@ -97,7 +95,7 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda data: _safe_round(data.get("Odo"), 0),
+        transform_fn=lambda x: _safe_round(x, 0),
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(
@@ -106,13 +104,13 @@ SENSOR_TYPES = [
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: _safe_round(data.get("SOC"), 2),
+        transform_fn=lambda x: _safe_round(x, 2),
     ),
     LeafSpySensorDescription(
         key="battery_capacity",
         translation_key="Ahr",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: _safe_round(data.get("Ahr"), 2),
+        transform_fn=lambda x: _safe_round(x, 2),
         native_unit_of_measurement="Ah",
         icon="mdi:battery-heart-variant",
     ),
@@ -122,8 +120,6 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("BatTemp"),
-        icon="mdi:thermometer",
     ),
     LeafSpySensorDescription(
         key="ambient_temperature",
@@ -131,7 +127,6 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("Amb"),
         icon="mdi:sun-thermometer",
     ),
     LeafSpySensorDescription(
@@ -140,19 +135,18 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("ChrgPwr"),
     ),
     LeafSpySensorDescription(
         key="front_wiper",
         translation_key="Wpr",
         device_class=SensorDeviceClass.ENUM,
-        value_fn=lambda data: {
+        transform_fn=lambda x: {
             80: "High",
             40: "Low",
             20: "Switch",
             10: "Intermittent",
             8: "Stopped"
-        }.get(int(data.get("Wpr")), "unknown"),
+        }.get(int(x), "unknown"),
         icon="mdi:wiper",
         options=[
             "High",
@@ -167,11 +161,11 @@ SENSOR_TYPES = [
         key="plug_state",
         translation_key="PlugState",
         device_class=SensorDeviceClass.ENUM,
-        value_fn=lambda data: {
+        transform_fn=lambda x: {
             0: "Not plugged",
             1: "Partial plugged",
             2: "Plugged"
-        }.get(int(data.get("PlugState")), "unknown"),
+        }.get(int(x), "unknown"),
         icon="mdi:power-plug",
         options=[
             "Not plugged",
@@ -184,12 +178,12 @@ SENSOR_TYPES = [
         key="charge_mode",
         translation_key="ChrgMode",
         device_class=SensorDeviceClass.ENUM,
-        value_fn=lambda data: {
+        transform_fn=lambda x: {
             0: "Not charging",
             1: "Level 1 charging",
             2: "Level 2 charging",
             3: "Level 3 quick charging"
-        }.get(int(data.get("ChrgMode")), "unknown"),
+        }.get(int(x), "unknown"),
         icon="mdi:ev-station",
         options=[
             "Not charging",
@@ -202,7 +196,6 @@ SENSOR_TYPES = [
     LeafSpySensorDescription(
         key="VIN",
         translation_key="VIN",
-        value_fn=lambda data: data.get("VIN"),
         icon="mdi:identifier",
     ),
     LeafSpySensorDescription(
@@ -210,7 +203,6 @@ SENSOR_TYPES = [
         translation_key="RPM",
         native_unit_of_measurement="RPM",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("RPM"),
         icon="mdi:engine",
     ),
     LeafSpySensorDescription(
@@ -218,7 +210,6 @@ SENSOR_TYPES = [
         translation_key="SOH",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("SOH"),
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
@@ -226,7 +217,7 @@ SENSOR_TYPES = [
         translation_key="Hx",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: _safe_round(_transform_hx(data.get("Hx")), 2),
+        transform_fn=lambda x: _safe_round(_transform_hx(x), 2),
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
@@ -235,7 +226,6 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("Speed"),
     ),
     LeafSpySensorDescription(
         key="battery_voltage",
@@ -243,7 +233,7 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: _safe_round(data.get("BatVolts"), 2),
+        transform_fn=lambda x: _safe_round(x, 2),
     ),
     LeafSpySensorDescription(
         key="battery_current",
@@ -251,7 +241,6 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("BatAmps"),
     ),
 ]
 
@@ -273,11 +262,18 @@ async def async_setup_entry(
 
             dev_id = slugify(f'leaf_{message["VIN"]}')
 
+            _LOGGER.debug(f"Incoming message: {message}")
+
             # Create and update sensors for each description
             for description in SENSOR_TYPES:
                 sensor_id = f"{dev_id}_{description.key}"
-                value = description.value_fn(message)
-                _LOGGER.debug("Sensor '%s': Raw data=%s, Parsed value=%s", description.key, message, value)
+                value = message.get(description.translation_key, None)
+                # value = description.value_fn(message)
+                _LOGGER.debug(f"Sensor {description.key}: Initial value={value}")
+
+                if description.transform_fn:
+                    value = description.transform_fn(value)
+                    _LOGGER.debug(f"Sensor {description.key}: Transformed value={value}")
 
                 if value is not None:
                     sensor = hass.data[DOMAIN]['sensors'].get(sensor_id)

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -47,16 +47,16 @@ def _safe_round(x, digits=2):
 
 SENSOR_TYPES = [
     LeafSpySensorDescription(
-        key="phone battery",
-        translation_key="phone_battery",
+        key="phone_battery",
+        translation_key="DevBat",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("DevBat"),
     ),
     LeafSpySensorDescription(
-        key="battery gids",
-        translation_key="battery_gids",
+        key="battery_gids",
+        translation_key="Gids",
         native_unit_of_measurement="Gids",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("Gids"),
@@ -64,7 +64,7 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="elevation",
-        translation_key="elevation",
+        translation_key="Elv",
         native_unit_of_measurement=UnitOfLength.METERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -72,20 +72,20 @@ SENSOR_TYPES = [
         icon="mdi:elevation-rise",
     ),
     LeafSpySensorDescription(
-        key="sequence number",
-        translation_key="sequence_number",
+        key="sequence_number",
+        translation_key="Seq",
         value_fn=lambda data: data.get("Seq"),
         icon="mdi:numeric",
     ),
     LeafSpySensorDescription(
-        key="trip number",
-        translation_key="trip_number",
+        key="trip_number",
+        translation_key="Trip",
         value_fn=lambda data: data.get("Trip"),
         icon="mdi:road-variant",
     ),
     LeafSpySensorDescription(
         key="odometer",
-        translation_key="odometer",
+        translation_key="Odo",
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -93,24 +93,24 @@ SENSOR_TYPES = [
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(
-        key="battery state of charge",
-        translation_key="state_of_charge",
+        key="battery_state_of_charge",
+        translation_key="SOC",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("SOC"),
+        value_fn=lambda data: _safe_round(data.get("SOC"), 2),
     ),
     LeafSpySensorDescription(
-        key="battery capacity",
-        translation_key="battery_capacity",
+        key="battery_capacity",
+        translation_key="Ahr",
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("AHr"),
+        value_fn=lambda data: _safe_round(data.get("Ahr"), 2),
         native_unit_of_measurement="Ah",
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
-        key="battery temperature",
-        translation_key="battery_temperature",
+        key="battery_temperature",
+        translation_key="BatTemp",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -118,8 +118,8 @@ SENSOR_TYPES = [
         icon="mdi:thermometer",
     ),
     LeafSpySensorDescription(
-        key="ambient temperature",
-        translation_key="ambient_temperature",
+        key="ambient_temperature",
+        translation_key="Amb",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -127,16 +127,16 @@ SENSOR_TYPES = [
         icon="mdi:sun-thermometer",
     ),
     LeafSpySensorDescription(
-        key="charge power",
-        translation_key="charge_power",
+        key="charge_power",
+        translation_key="ChrgPwr",
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("ChrgPwr"),
     ),
     LeafSpySensorDescription(
-        key="front wiper",
-        translation_key="front_wiper",
+        key="front_wiper",
+        translation_key="Wpr",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: {
             80: "High",
@@ -156,8 +156,8 @@ SENSOR_TYPES = [
         ]
     ),
     LeafSpySensorDescription(
-        key="plug",
-        translation_key="plug",
+        key="plug_state",
+        translation_key="PlugState",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: {
             0: "Not plugged",
@@ -173,8 +173,8 @@ SENSOR_TYPES = [
         ]
     ),
     LeafSpySensorDescription(
-        key="charge mode",
-        translation_key="charge_mode",
+        key="charge_mode",
+        translation_key="ChrgMode",
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda data: {
             0: "Not charging",
@@ -182,7 +182,7 @@ SENSOR_TYPES = [
             2: "Level 2 charging",
             3: "Level 3 quick charging"
         }.get(int(data.get("ChrgMode")), "unknown"),
-        icon="mdi:battery-charging-wireless",
+        icon="mdi:ev-station",
         options=[
             "Not charging",
             "Level 1 charging",
@@ -198,24 +198,24 @@ SENSOR_TYPES = [
         icon="mdi:identifier",
     ),
     LeafSpySensorDescription(
-        key="motor speed",
-        translation_key="motor_speed",
+        key="motor_speed",
+        translation_key="RPM",
         native_unit_of_measurement="RPM",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("RPM"),
         icon="mdi:engine",
     ),
     LeafSpySensorDescription(
-        key="battery health",
-        translation_key="battery_health",
+        key="battery_health",
+        translation_key="SOH",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("SOH"),
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
-        key="battery conductance",
-        translation_key="battery_conductance",
+        key="battery_conductance",
+        translation_key="Hx",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("Hx"),
@@ -223,23 +223,23 @@ SENSOR_TYPES = [
     ),
     LeafSpySensorDescription(
         key="speed",
-        translation_key="speed",
+        translation_key="Speed",
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
         device_class=SensorDeviceClass.SPEED,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("Speed"),
     ),
     LeafSpySensorDescription(
-        key="battery voltage",
-        translation_key="battery_voltage",
+        key="battery_voltage",
+        translation_key="BatVolts",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("BatVolts"),
+        value_fn=lambda data: _safe_round(data.get("BatVolts"), 2),
     ),
     LeafSpySensorDescription(
-        key="battery current",
-        translation_key="battery_current",
+        key="battery_current",
+        translation_key="BatAmps",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -328,6 +328,7 @@ class LeafSpySensor(RestoreSensor):
         """Initialize the sensor."""
         self._device_id = device_id
         self._value = initial_value
+        self._attr_has_entity_name = True
         self.entity_description = description
 
     @property
@@ -335,11 +336,12 @@ class LeafSpySensor(RestoreSensor):
         """Return a unique ID."""
         return f"{self._device_id}_{self.entity_description.key}"
 
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return f"Leaf {self.entity_description.key}"
 
+    @property
+    def translation_key(self):
+        """Return the translation key."""
+        return self.entity_description.translation_key
+    
     @property
     def native_value(self):
         """Return the sensor's value."""

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -95,7 +95,7 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        transform_fn=lambda x: _safe_round(x, 0),
+        transform_fn=lambda x: _safe_round(x, 1),
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(
@@ -268,7 +268,7 @@ async def async_setup_entry(
             for description in SENSOR_TYPES:
                 sensor_id = f"{dev_id}_{description.key}"
                 value = message.get(description.translation_key, None)
-                # value = description.value_fn(message)
+
                 _LOGGER.debug(f"Sensor {description.key}: Initial value={value}")
 
                 if description.transform_fn:

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -43,6 +43,14 @@ def _safe_round(x, digits=2):
             return round(float(x), digits)
     except (ValueError, TypeError):
         return None
+    
+def _transform_hx(x):
+    # if x > 100, divide by 102.4, otherwise return
+    # takes care of iOS LeafSpy bug until patched
+    if x > 100:
+        return x / 102.4
+    else:
+        return x
 
 
 SENSOR_TYPES = [
@@ -218,7 +226,7 @@ SENSOR_TYPES = [
         translation_key="Hx",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.get("Hx"),
+        value_fn=lambda data: _safe_round(_transform_hx(data.get("Hx")), 2),
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -95,7 +95,7 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        transform_fn=lambda x: _safe_round(x, 1),
+        transform_fn=lambda x: _safe_round(x, 0),
         icon="mdi:counter",
     ),
     LeafSpySensorDescription(

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -228,9 +228,9 @@ SENSOR_TYPES = [
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
-        key="battery conductance",
+        key="battery conductance (Hx)",
         translation_key="battery_conductance",
-        native_unit_of_measurement='Hx',
+        native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: data.get("Hx"),
         icon="mdi:battery-heart-variant",

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -349,6 +349,7 @@ class LeafSpySensor(RestoreSensor):
     def device_info(self):
         """Return device information."""
         return {
+            "name": "Leaf",
             "identifiers": {(DOMAIN, self._device_id)},
         }
     

--- a/custom_components/leafspy/sensor.py
+++ b/custom_components/leafspy/sensor.py
@@ -58,54 +58,12 @@ def _transform_hx(x):
 
 SENSOR_TYPES = [
     LeafSpySensorDescription(
-        key="phone_battery",
-        leafspy_key="DevBat",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
+        key="ambient_temperature",
+        leafspy_key="Amb",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-    ),
-    LeafSpySensorDescription(
-        key="battery_gids",
-        leafspy_key="Gids",
-        native_unit_of_measurement="Gids",
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-    ),
-    LeafSpySensorDescription(
-        key="elevation",
-        leafspy_key="Elv",
-        native_unit_of_measurement=UnitOfLength.METERS,
-        device_class=SensorDeviceClass.DISTANCE,
-        state_class=SensorStateClass.MEASUREMENT,
-        transform_fn=lambda x: _safe_round(x, 2),
-        icon="mdi:elevation-rise",
-    ),
-    LeafSpySensorDescription(
-        key="sequence_number",
-        leafspy_key="Seq",
-        icon="mdi:numeric",
-    ),
-    LeafSpySensorDescription(
-        key="trip_number",
-        leafspy_key="Trip",
-        icon="mdi:road-variant",
-    ),
-    LeafSpySensorDescription(
-        key="odometer",
-        leafspy_key="Odo",
-        native_unit_of_measurement=UnitOfLength.KILOMETERS,
-        device_class=SensorDeviceClass.DISTANCE,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        transform_fn=lambda x: _safe_round(x, 1),
-        icon="mdi:counter",
-    ),
-    LeafSpySensorDescription(
-        key="battery_state_of_charge",
-        leafspy_key="SOC",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
-        state_class=SensorStateClass.MEASUREMENT,
-        transform_fn=lambda x: _safe_round(x, 2),
+        icon="mdi:sun-thermometer",
     ),
     LeafSpySensorDescription(
         key="battery_capacity",
@@ -116,6 +74,43 @@ SENSOR_TYPES = [
         icon="mdi:battery-heart-variant",
     ),
     LeafSpySensorDescription(
+        key="battery_conductance",
+        leafspy_key="Hx",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        transform_fn=lambda x: _safe_round(_transform_hx(x), 2),
+        icon="mdi:battery-heart-variant",
+    ),
+    LeafSpySensorDescription(
+        key="battery_current",
+        leafspy_key="BatAmps",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    LeafSpySensorDescription(
+        key="battery_health",
+        leafspy_key="SOH",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery-heart-variant",
+    ),
+    LeafSpySensorDescription(
+        key="battery_state_of_charge",
+        leafspy_key="SOC",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        transform_fn=lambda x: _safe_round(x, 2),
+    ),
+    LeafSpySensorDescription(
+        key="battery_gids",
+        leafspy_key="Gids",
+        native_unit_of_measurement="Gids",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery",
+    ),
+    LeafSpySensorDescription(
         key="battery_temperature",
         leafspy_key="BatTemp",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -123,12 +118,31 @@ SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LeafSpySensorDescription(
-        key="ambient_temperature",
-        leafspy_key="Amb",
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        device_class=SensorDeviceClass.TEMPERATURE,
+        key="battery_voltage",
+        leafspy_key="BatVolts",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:sun-thermometer",
+        transform_fn=lambda x: _safe_round(x, 2),
+    ),
+    LeafSpySensorDescription(
+        key="charge_mode",
+        leafspy_key="ChrgMode",
+        device_class=SensorDeviceClass.ENUM,
+        transform_fn=lambda x: {
+            0: "Not charging",
+            1: "Level 1 charging",
+            2: "Level 2 charging",
+            3: "Level 3 quick charging"
+        }.get(int(x), "unknown"),
+        icon="mdi:ev-station",
+        options=[
+            "Not charging",
+            "Level 1 charging",
+            "Level 2 charging", 
+            "Level 3 quick charging",
+            "unknown"
+        ]
     ),
     LeafSpySensorDescription(
         key="charge_power",
@@ -136,6 +150,15 @@ SENSOR_TYPES = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+    LeafSpySensorDescription(
+        key="elevation",
+        leafspy_key="Elv",
+        native_unit_of_measurement=UnitOfLength.METERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        transform_fn=lambda x: _safe_round(x, 2),
+        icon="mdi:elevation-rise",
     ),
     LeafSpySensorDescription(
         key="front_wiper",
@@ -159,6 +182,29 @@ SENSOR_TYPES = [
         ]
     ),
     LeafSpySensorDescription(
+        key="motor_speed",
+        leafspy_key="RPM",
+        native_unit_of_measurement="RPM",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:engine",
+    ),
+    LeafSpySensorDescription(
+        key="odometer",
+        leafspy_key="Odo",
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        transform_fn=lambda x: _safe_round(x, 1),
+        icon="mdi:counter",
+    ),
+    LeafSpySensorDescription(
+        key="phone_battery",
+        leafspy_key="DevBat",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    LeafSpySensorDescription(
         key="plug_state",
         leafspy_key="PlugState",
         device_class=SensorDeviceClass.ENUM,
@@ -176,50 +222,9 @@ SENSOR_TYPES = [
         ]
     ),
     LeafSpySensorDescription(
-        key="charge_mode",
-        leafspy_key="ChrgMode",
-        device_class=SensorDeviceClass.ENUM,
-        transform_fn=lambda x: {
-            0: "Not charging",
-            1: "Level 1 charging",
-            2: "Level 2 charging",
-            3: "Level 3 quick charging"
-        }.get(int(x), "unknown"),
-        icon="mdi:ev-station",
-        options=[
-            "Not charging",
-            "Level 1 charging",
-            "Level 2 charging", 
-            "Level 3 quick charging",
-            "unknown"
-        ]
-    ),
-    LeafSpySensorDescription(
-        key="vin",
-        leafspy_key="VIN",
-        icon="mdi:identifier",
-    ),
-    LeafSpySensorDescription(
-        key="motor_speed",
-        leafspy_key="RPM",
-        native_unit_of_measurement="RPM",
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:engine",
-    ),
-    LeafSpySensorDescription(
-        key="battery_health",
-        leafspy_key="SOH",
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery-heart-variant",
-    ),
-    LeafSpySensorDescription(
-        key="battery_conductance",
-        leafspy_key="Hx",
-        native_unit_of_measurement=PERCENTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        transform_fn=lambda x: _safe_round(_transform_hx(x), 2),
-        icon="mdi:battery-heart-variant",
+        key="sequence_number",
+        leafspy_key="Seq",
+        icon="mdi:numeric",
     ),
     LeafSpySensorDescription(
         key="speed",
@@ -229,19 +234,14 @@ SENSOR_TYPES = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LeafSpySensorDescription(
-        key="battery_voltage",
-        leafspy_key="BatVolts",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        transform_fn=lambda x: _safe_round(x, 2),
+        key="trip_number",
+        leafspy_key="Trip",
+        icon="mdi:road-variant",
     ),
     LeafSpySensorDescription(
-        key="battery_current",
-        leafspy_key="BatAmps",
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        device_class=SensorDeviceClass.CURRENT,
-        state_class=SensorStateClass.MEASUREMENT,
+        key="vin",
+        leafspy_key="VIN",
+        icon="mdi:identifier",
     ),
 ]
 

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -4,12 +4,12 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: On\n - `'Send Interval'`: Whatever frequency you prefer.\n - `'ID'`: Whatever name you prefer for the `device_tracker` entity. `'Leaf'` is fine.'`\n - `'PW'`: {secret}\n - `'Http://'` or `'Https://'`: Depends on your Home Assistant installation.\n - `'URL'`: {url}\n   - _(**Do not** include the http or https prefix in the URL field.)_"
+      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`.\n   - Enable `Convert Outside Temperature`.\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer.\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation.\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"    },
     },
     "step": {
       "user": {
-        "description": "Are you sure you want to set up LeafSpy?",
-        "title": "Set up LeafSpy"
+        "description": "Are you sure you want to set up Leaf Spy?",
+        "title": "Set up Leaf Spy"
       }
     }
   },

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -15,72 +15,72 @@
   },
   "entity": {
     "binary_sensor": {
-      "PwrSw": {
+      "power": {
         "name": "Power"
       }
     },
     "sensor": {
-      "DevBat": {
+      "phone_battery": {
         "name": "Phone battery"
       },
-      "Gids": {
+      "battery_gids": {
         "name": "Battery state of charge (Gids)"
       },
-      "Elv": {
+      "elevation": {
         "name": "Elevation"
       },
-      "Seq": {
+      "sequence_number": {
         "name": "Sequence number"
       },
-      "Trip": {
+      "trip_number": {
         "name": "Trip number"
       },
-      "Odo": {
+      "odometer": {
         "name": "Odometer"
       },
-      "SOC": {
+      "battery_state_of_charge": {
         "name": "Battery state of charge"
       },
-      "AHr": {
+      "battery_capacity": {
         "name": "Battery capacity"
       },
-      "BatTemp": {
+      "battery_temperature": {
         "name": "Battery temperature"
       },
-      "Amb": {
+      "ambient_temperature": {
         "name": "Ambient temperature"
       },
-      "ChrgPwr": {
+      "charge_power": {
         "name": "Charge power"
       },
-      "Wpr": {
+      "front_wiper": {
         "name": "Front wiper status"
       },
-      "PlugState": {
+      "plug_state": {
         "name": "Plug status"
       },
-      "ChrgMode": {
+      "charge_mode": {
         "name": "Charge mode"
       },
-      "VIN": {
+      "vin": {
         "name": "VIN"
       },
-      "RPM": {
+      "motor_speed": {
         "name": "Motor speed"
       },
-      "SOH": {
+      "battery_health": {
         "name": "Battery health"
       },
-      "Hx": {
+      "battery_conductance": {
         "name": "Battery conductance (Hx)"
       },
-      "Speed": {
+      "speed": {
         "name": "Speed"
       },
-      "BatVolts": {
+      "battery_voltage": {
         "name": "Battery voltage"
       },
-      "BatAmps": {
+      "battery_current": {
         "name": "Battery current"
       }
     }

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -14,6 +14,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "PwrSw": {
+        "name": "Power"
+      }
+    },
     "sensor": {
       "DevBat": {
         "name": "Phone battery"

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -4,12 +4,79 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: On\n - `'Send Interval'`: Whatever frequency you prefer.\n - `'ID'`: Whatever name you prefer for the `device_tracker` entity. `'Leaf'` is fine.'`\n - `'PW'`: {secret}\n - `'Http://'` or `'Https://'`: Depends on your Home Assistant installation.\n - `'URL'`: {url}\n   - _(**Do not** include the http or https prefix in the URL field.)_"
     },
     "step": {
       "user": {
-        "description": "Are you sure you want to set up Leaf Spy?",
-        "title": "Set up Leaf Spy"
+        "description": "Are you sure you want to set up LeafSpy?",
+        "title": "Set up LeafSpy"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "DevBat": {
+        "name": "Phone battery"
+      },
+      "Gids": {
+        "name": "Battery state of charge (Gids)"
+      },
+      "Elv": {
+        "name": "Elevation"
+      },
+      "Seq": {
+        "name": "Sequence number"
+      },
+      "Trip": {
+        "name": "Trip number"
+      },
+      "Odo": {
+        "name": "Odometer"
+      },
+      "SOC": {
+        "name": "Battery state of charge"
+      },
+      "Ahr": {
+        "name": "Battery capacity"
+      },
+      "BatTemp": {
+        "name": "Battery temperature"
+      },
+      "Amb": {
+        "name": "Ambient temperature"
+      },
+      "ChrgPwr": {
+        "name": "Charge power"
+      },
+      "Wpr": {
+        "name": "Front wiper status"
+      },
+      "PlugState": {
+        "name": "Plug state"
+      },
+      "ChrgMode": {
+        "name": "Charge mode"
+      },
+      "VIN": {
+        "name": "VIN"
+      },
+      "RPM": {
+        "name": "Motor speed"
+      },
+      "SOH": {
+        "name": "Battery health"
+      },
+      "Hx": {
+        "name": "Battery conductance"
+      },
+      "Speed": {
+        "name": "Speed"
+      },
+      "BatVolts": {
+        "name": "Battery voltage"
+      },
+      "BatAmps": {
+        "name": "Battery current"
       }
     }
   }

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -41,7 +41,7 @@
       "SOC": {
         "name": "Battery state of charge"
       },
-      "Ahr": {
+      "AHr": {
         "name": "Battery capacity"
       },
       "BatTemp": {
@@ -57,7 +57,7 @@
         "name": "Front wiper status"
       },
       "PlugState": {
-        "name": "Plug state"
+        "name": "Plug status"
       },
       "ChrgMode": {
         "name": "Charge mode"
@@ -72,7 +72,7 @@
         "name": "Battery health"
       },
       "Hx": {
-        "name": "Battery conductance"
+        "name": "Battery conductance (Hx)"
       },
       "Speed": {
         "name": "Speed"

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -4,7 +4,7 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`.\n   - Enable `Convert Outside Temperature`.\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer.\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation.\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"    },
+      "default": "Open the LeafSpy app, go to `Menu` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`\n   - `Convert Outside Temperature`: `On`.\n   - `CAN Odometer in Miles`: `On` (if you see the option and if your car odometer displays in miles)\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"
     },
     "step": {
       "user": {

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -4,7 +4,7 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
     },
     "step": {
       "user": {

--- a/custom_components/leafspy/strings.json
+++ b/custom_components/leafspy/strings.json
@@ -4,7 +4,7 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "Open the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: On\n - `'Send Interval'`: Whatever frequency you prefer.\n - `'ID'`: Whatever device name you prefer. `Leaf` is probably best, unless you have more than one.\n - `'PW'`: `{secret}`\n - `'Http://'` or `'Https://'`: Depends on your Home Assistant installation.\n - `'URL'`: `{url}`\n   - _(**Do not** include the http or https prefix in the URL field.)_"
     },
     "step": {
       "user": {

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -15,72 +15,72 @@
   },
   "entity": {
     "binary_sensor": {
-      "PwrSw": {
+      "power": {
         "name": "Power"
       }
     },
     "sensor": {
-      "DevBat": {
+      "phone_battery": {
         "name": "Phone battery"
       },
-      "Gids": {
+      "battery_gids": {
         "name": "Battery state of charge (Gids)"
       },
-      "Elv": {
+      "elevation": {
         "name": "Elevation"
       },
-      "Seq": {
+      "sequence_number": {
         "name": "Sequence number"
       },
-      "Trip": {
+      "trip_number": {
         "name": "Trip number"
       },
-      "Odo": {
+      "odometer": {
         "name": "Odometer"
       },
-      "SOC": {
+      "battery_state_of_charge": {
         "name": "Battery state of charge"
       },
-      "AHr": {
+      "battery_capacity": {
         "name": "Battery capacity"
       },
-      "BatTemp": {
+      "battery_temperature": {
         "name": "Battery temperature"
       },
-      "Amb": {
+      "ambient_temperature": {
         "name": "Ambient temperature"
       },
-      "ChrgPwr": {
+      "charge_power": {
         "name": "Charge power"
       },
-      "Wpr": {
+      "front_wiper": {
         "name": "Front wiper status"
       },
-      "PlugState": {
+      "plug_state": {
         "name": "Plug status"
       },
-      "ChrgMode": {
+      "charge_mode": {
         "name": "Charge mode"
       },
-      "VIN": {
+      "vin": {
         "name": "VIN"
       },
-      "RPM": {
+      "motor_speed": {
         "name": "Motor speed"
       },
-      "SOH": {
+      "battery_health": {
         "name": "Battery health"
       },
-      "Hx": {
+      "battery_conductance": {
         "name": "Battery conductance (Hx)"
       },
-      "Speed": {
+      "speed": {
         "name": "Speed"
       },
-      "BatVolts": {
+      "battery_voltage": {
         "name": "Battery voltage"
       },
-      "BatAmps": {
+      "battery_current": {
         "name": "Battery current"
       }
     }

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -4,7 +4,8 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`.\n   - Enable `Convert Outside Temperature`.\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer.\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation.\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"    },
+      "default": "Open the LeafSpy app, go to `Menu` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`\n   - `Convert Outside Temperature`: `On`.\n   - `CAN Odometer in Miles`: `On` (if you see the option and if your car odometer displays in miles)\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"
+    },
     "step": {
       "user": {
         "description": "Are you sure you want to set up Leaf Spy?",

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -13,6 +13,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "PwrSw": {
+        "name": "Power"
+      }
+    },
     "sensor": {
       "DevBat": {
         "name": "Phone battery"

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -4,12 +4,79 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: On\n - `'Send Interval'`: Whatever frequency you prefer.\n - `'ID'`: Whatever name you prefer for the `device_tracker` entity. `'Leaf'` is fine.'`\n - `'PW'`: {secret}\n - `'Http://'` or `'Https://'`: Depends on your Home Assistant installation.\n - `'URL'`: {url}\n   - _(**Do not** include the http or https prefix in the URL field.)_"
     },
     "step": {
       "user": {
-        "description": "Are you sure you want to set up Leaf Spy?",
-        "title": "Set up Leaf Spy"
+        "description": "Are you sure you want to set up LeafSpy?",
+        "title": "Set up LeafSpy"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "DevBat": {
+        "name": "Phone battery"
+      },
+      "Gids": {
+        "name": "Battery state of charge (Gids)"
+      },
+      "Elv": {
+        "name": "Elevation"
+      },
+      "Seq": {
+        "name": "Sequence number"
+      },
+      "Trip": {
+        "name": "Trip number"
+      },
+      "Odo": {
+        "name": "Odometer"
+      },
+      "SOC": {
+        "name": "Battery state of charge"
+      },
+      "Ahr": {
+        "name": "Battery capacity"
+      },
+      "BatTemp": {
+        "name": "Battery temperature"
+      },
+      "Amb": {
+        "name": "Ambient temperature"
+      },
+      "ChrgPwr": {
+        "name": "Charge power"
+      },
+      "Wpr": {
+        "name": "Front wiper status"
+      },
+      "PlugState": {
+        "name": "Plug state"
+      },
+      "ChrgMode": {
+        "name": "Charge mode"
+      },
+      "VIN": {
+        "name": "VIN"
+      },
+      "RPM": {
+        "name": "Motor speed"
+      },
+      "SOH": {
+        "name": "Battery health"
+      },
+      "Hx": {
+        "name": "Battery conductance"
+      },
+      "Speed": {
+        "name": "Speed"
+      },
+      "BatVolts": {
+        "name": "Battery voltage"
+      },
+      "BatAmps": {
+        "name": "Battery current"
       }
     }
   }

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -7,8 +7,8 @@
       "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`.\n   - Enable `Convert Outside Temperature`.\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer.\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation.\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"    },
     "step": {
       "user": {
-        "description": "Are you sure you want to set up LeafSpy?",
-        "title": "Set up LeafSpy"
+        "description": "Are you sure you want to set up Leaf Spy?",
+        "title": "Set up Leaf Spy"
       }
     }
   },
@@ -40,7 +40,7 @@
       "SOC": {
         "name": "Battery state of charge"
       },
-      "Ahr": {
+      "AHr": {
         "name": "Battery capacity"
       },
       "BatTemp": {
@@ -56,7 +56,7 @@
         "name": "Front wiper status"
       },
       "PlugState": {
-        "name": "Plug state"
+        "name": "Plug status"
       },
       "ChrgMode": {
         "name": "Charge mode"
@@ -71,7 +71,7 @@
         "name": "Battery health"
       },
       "Hx": {
-        "name": "Battery conductance"
+        "name": "Battery conductance (Hx)"
       },
       "Speed": {
         "name": "Speed"

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -4,8 +4,7 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: On\n - `'Send Interval'`: Whatever frequency you prefer.\n - `'ID'`: Whatever name you prefer for the `device_tracker` entity. `'Leaf'` is fine.'`\n - `'PW'`: {secret}\n - `'Http://'` or `'Https://'`: Depends on your Home Assistant installation.\n - `'URL'`: {url}\n   - _(**Do not** include the http or https prefix in the URL field.)_"
-    },
+      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - In the **Units** section:\n   - Choose `°C`.\n   - Enable `Convert Outside Temperature`.\n - In the **Server** section:\n   - `Enable`: `On`\n   - `Send Interval`: Whatever frequency you prefer.\n   - `PW`: `{secret}`\n   - `Http://` or `Https://`: Depends on your Home Assistant installation.\n   - `URL`: `{url}`\n     - _(**Do not** include the http or https prefix in the URL field.)_"    },
     "step": {
       "user": {
         "description": "Are you sure you want to set up LeafSpy?",

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -20,68 +20,68 @@
       }
     },
     "sensor": {
-      "phone_battery": {
-        "name": "Phone battery"
-      },
-      "battery_gids": {
-        "name": "Battery state of charge (Gids)"
-      },
-      "elevation": {
-        "name": "Elevation"
-      },
-      "sequence_number": {
-        "name": "Sequence number"
-      },
-      "trip_number": {
-        "name": "Trip number"
-      },
-      "odometer": {
-        "name": "Odometer"
-      },
-      "battery_state_of_charge": {
-        "name": "Battery state of charge"
+      "ambient_temperature": {
+        "name": "Ambient temperature"
       },
       "battery_capacity": {
         "name": "Battery capacity"
       },
-      "battery_temperature": {
-        "name": "Battery temperature"
+      "battery_conductance": {
+        "name": "Battery conductance (Hx)"
       },
-      "ambient_temperature": {
-        "name": "Ambient temperature"
-      },
-      "charge_power": {
-        "name": "Charge power"
-      },
-      "front_wiper": {
-        "name": "Front wiper status"
-      },
-      "plug_state": {
-        "name": "Plug status"
-      },
-      "charge_mode": {
-        "name": "Charge mode"
-      },
-      "vin": {
-        "name": "VIN"
-      },
-      "motor_speed": {
-        "name": "Motor speed"
+      "battery_current": {
+        "name": "Battery current"
       },
       "battery_health": {
         "name": "Battery health"
       },
-      "battery_conductance": {
-        "name": "Battery conductance (Hx)"
+      "battery_state_of_charge": {
+        "name": "Battery state of charge"
       },
-      "speed": {
-        "name": "Speed"
+      "battery_gids": {
+        "name": "Battery state of charge (Gids)"
+      },
+      "battery_temperature": {
+        "name": "Battery temperature"
       },
       "battery_voltage": {
         "name": "Battery voltage"
       },
-      "battery_current": {
-        "name": "Battery current"
+      "charge_mode": {
+        "name": "Charge mode"
+      },
+      "charge_power": {
+        "name": "Charge power"
+      },
+      "elevation": {
+        "name": "Elevation"
+      },
+      "front_wiper": {
+        "name": "Front wiper status"
+      },
+      "motor_speed": {
+        "name": "Motor speed"
+      },
+      "odometer": {
+        "name": "Odometer"
+      },
+      "phone_battery": {
+        "name": "Phone battery"
+      },
+      "plug_state": {
+        "name": "Plug status"
+      },
+      "sequence_number": {
+        "name": "Sequence number"
+      },
+      "speed": {
+        "name": "Speed"
+      },
+      "trip_number": {
+        "name": "Trip number"
+      },
+      "vin": {
+        "name": "VIN"
       }
     }
   }

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -4,7 +4,7 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "Open the LeafSpy app, go to `'Menu'` -> `'Settings'`.\n - Set `'Units'` to `'°C'`.\n - Enable `'Convert Outside Temperatures'`.\n - Scroll down to the `'Server'` section. Change the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
     },
     "step": {
       "user": {

--- a/custom_components/leafspy/translations/en.json
+++ b/custom_components/leafspy/translations/en.json
@@ -4,7 +4,7 @@
       "one_instance_allowed": "You may have only one instance of Leaf Spy installed, and you appear to have installed one already."
     },
     "create_entry": {
-      "default": "Open the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: Yes\n - `'Send Interval'` can be whatever you prefer.\n - `'ID'`: `'(Car Name)'`\n - `'PW'`: {secret}\n - `'Http'` or `'Https'` depending on the access to your Home Assistant install.\n - `'URL'`: {url} - Note: **Do not** add http or https to the URL."
+      "default": "Open the Leaf Spy app, go to `'Menu'` -> `'Settings'` and scroll down to `'Server'`. \nChange the following settings:\n - `'Enable'`: On\n - `'Send Interval'`: Whatever frequency you prefer.\n - `'ID'`: Whatever device name you prefer. `Leaf` is probably best, unless you have more than one.\n - `'PW'`: `{secret}`\n - `'Http://'` or `'Https://'`: Depends on your Home Assistant installation.\n - `'URL'`: `{url}`\n   - _(**Do not** include the http or https prefix in the URL field.)_"
     },
     "step": {
       "user": {


### PR DESCRIPTION
So far, this integration has exposed one `device_tracker` entity, with attributes for the sensor data that LeafSpy provides. This PR instead provides that sensor data as proper entities.